### PR TITLE
Adding Ubuntu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Easiest way for distributing the PBIS Open packages is using local `yum` rep
 
 ## Supported platforms
 Redhat/CentOS 6.x
+
 Ubuntu 14.04
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Ansible playbook for deploying PowerBroker Identity Services PBIS Open Edition f
 
 ## Distributing PBIS package
 
-The Easiest  way for distributing the PBIS Open packages is using local `yum` repository.
+The Easiest way for distributing the PBIS Open packages is using local `yum` repository.
 
 1. Download the package from [BeyondTrust Website](http://download1.beyondtrust.com/Technical-Support/Downloads/PowerBroker-Identity-Services-Open-Edition/?Pass=True)
 2. Exctract the package and move the rpm files `pbis-open-8.2.1-2979.x86_64.rpm pbis-open-gui-8.2.1-2979.x86_64.rpm pbis-open-upgrade-8.2.1-2979.x86_64.rpm` to  for example `/var/www/packages/pbis` folder (nginx or apache)
@@ -14,17 +14,15 @@ The Easiest  way for distributing the PBIS Open packages is using local `yum` re
 
 ## Variables
 * `username:` and `password:` of a domain user with granted add/remove computers to the domain
-* `url:` http adress of your yum repo 
+* `url:` http adress of your yum repo
 * `mydomain:` netbios name of your domain
- 
+
 
 ## Supported platforms
 Redhat/CentOS 6.x
+Ubuntu 14.04
 
 
 ## todo
 * add a module or sh script to download pbis and update rpm repository
 * extend the script for ubuntu/debian
-
-
-

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The Easiest way for distributing the PBIS Open packages is using local `yum` rep
 
 
 ## Variables
-* `username:` and `password:` of a domain user with granted add/remove computers to the domain
-* `url:` http adress of your yum repo
-* `mydomain:` netbios name of your domain
-
+* `domain_user:` and `domain_pass:` of a domain user with granted add/remove computers to the domain
+* `domain_fqdn:` Full qualified domain name of your domain, e.g. office.contoso.com
+* `domain_netbios:` NetBIOS domain name, e.g. CONTOSO
+* `url:` http adress of your yum repo if using Redhat
 
 ## Supported platforms
 * Redhat/CentOS 6.x

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 
 Ansible playbook for deploying PowerBroker Identity Services PBIS Open Edition for RedHat/CentOS
 
+## Ubuntu PBIS package
+The Ubuntu support adds and installs from the http://repo.pbis.beyondtrust.com/apt.html repo
+
 ## Distributing PBIS package
 
 The Easiest way for distributing the PBIS Open packages is using local `yum` repository.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ The Easiest way for distributing the PBIS Open packages is using local `yum` rep
 
 
 ## Supported platforms
-Redhat/CentOS 6.x
-
-Ubuntu 14.04
+* Redhat/CentOS 6.x
+* Ubuntu 14.04
 
 
 ## todo
 * add a module or sh script to download pbis and update rpm repository
-* extend the script for ubuntu/debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Alen Stimec 
-  description: Ansible playbook for deploying PowerBroker Identity Services PBIS Open Edition for RedHat/CentOS
+  author: Alen Stimec
+  description: Ansible playbook for deploying PowerBroker Identity Services PBIS Open Edition for RedHat/CentOS/Ubuntu
   company: future.inc
   license: MIT
   min_ansible_version: 1.2
@@ -10,6 +10,9 @@ galaxy_info:
   - name: EL
     versions:
      - 6
+  - name: Ubuntu
+    versions:
+     - trusty
 
   categories:
   - system

--- a/roles/pbis/handlers/main.yml
+++ b/roles/pbis/handlers/main.yml
@@ -6,3 +6,6 @@
 
    - name: config pbis shell
      command: /opt/pbis/bin/config LoginShellTemplate /bin/bash
+
+   - name: config pbis homedirtemplate
+     command: /opt/pbis/bin/config HomeDirTemplate %H/%U

--- a/roles/pbis/handlers/main.yml
+++ b/roles/pbis/handlers/main.yml
@@ -1,10 +1,8 @@
 ---
 # handlers file for pbis
 
-   - name: config pbis domain 
-     command: /opt/pbis/bin/onfig AssumeDefaultDomain true
+   - name: config pbis domain
+     command: /opt/pbis/bin/config AssumeDefaultDomain true
 
    - name: config pbis shell
-     command: /opt/pbis/bin/config  LoginShellTemplate /bin/bash
-
-
+     command: /opt/pbis/bin/config LoginShellTemplate /bin/bash

--- a/roles/pbis/handlers/main.yml
+++ b/roles/pbis/handlers/main.yml
@@ -9,3 +9,6 @@
 
    - name: config pbis homedirtemplate
      command: /opt/pbis/bin/config HomeDirTemplate %H/%U
+
+   - name: config pbis UserDomainPrefix
+     command: /opt/pbis/bin/config UserDomainPrefix {{ domain_fqdn }}

--- a/roles/pbis/meta/main.yml
+++ b/roles/pbis/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  author: Alen Stimec 
+  author: Alen Stimec
   description: Ansible playbook for deploying PowerBroker Identity Services PBIS Open Edition for RedHat/CentOS
   company: future.inc
   license: MIT
@@ -10,6 +10,9 @@ galaxy_info:
   - name: EL
     versions:
      - 6
+  - name: Ubuntu
+    versions:
+     - 'trusty'
 
   categories:
   - system

--- a/roles/pbis/tasks/main.yml
+++ b/roles/pbis/tasks/main.yml
@@ -18,3 +18,4 @@
      notify:
           - config pbis shell
           - config pbis domain
+          - config pbis homedirtemplate

--- a/roles/pbis/tasks/main.yml
+++ b/roles/pbis/tasks/main.yml
@@ -1,24 +1,20 @@
 ---
 # tasks file for pbis
+   - include: redhat.yml
+     when: ansible_os_family == 'RedHat'
 
-   - name: copy pbis.repo file
-     template: src=pbis.repo.j2 dest=/etc/yum.repos.d/pbis.repo
-
-   - name: refresh yum cache
-     command: yum --disablerepo=* --enablerepo=pbis clean all 
- 
-   - name: install pbis
-     yum: name=pbis* state=latest 
+   - include: ubuntu.yml
+     when: when: ansible_lsb.id == 'Ubuntu'
 
 
    - name: check the Domain status
      shell: /opt/pbis/bin/lsa get-status |grep Netbios |awk '{print $3}'
      register: domain_status
-  
+
 
    - name: Join the machine if it is not already on the domain.
      command: /usr/bin/domainjoin-cli join internetq.corp {{ username }} {{password}}
      when: domain_status.stdout != "{{mydomain}}"
-     notify: 
+     notify:
           - config pbis shell
           - config pbis domain

--- a/roles/pbis/tasks/main.yml
+++ b/roles/pbis/tasks/main.yml
@@ -4,7 +4,7 @@
      when: ansible_os_family == 'RedHat'
 
    - include: ubuntu.yml
-     when: when: ansible_lsb.id == 'Ubuntu'
+     when: ansible_lsb.id == 'Ubuntu'
 
 
    - name: check the Domain status

--- a/roles/pbis/tasks/main.yml
+++ b/roles/pbis/tasks/main.yml
@@ -6,15 +6,13 @@
    - include: ubuntu.yml
      when: ansible_lsb.id == 'Ubuntu'
 
-
    - name: check the Domain status
      shell: /opt/pbis/bin/lsa get-status |grep Netbios |awk '{print $3}'
      register: domain_status
 
-
    - name: Join the machine if it is not already on the domain.
-     command: /usr/bin/domainjoin-cli join internetq.corp {{ username }} {{password}}
-     when: domain_status.stdout != "{{mydomain}}"
+     command: /usr/bin/domainjoin-cli join {{ domain_fqdn }} {{ domain_user }} {{ domain_pass }}
+     when: domain_status.stdout != "{{ domain_netbios }}"
      notify:
           - config pbis shell
           - config pbis domain

--- a/roles/pbis/tasks/redhat.yml
+++ b/roles/pbis/tasks/redhat.yml
@@ -1,11 +1,10 @@
 ---
 # tasks file for pbis on Redhat
-
-   - name: copy pbis.repo file
+   - name: Redhat | copy pbis.repo file
      template: src=pbis.repo.j2 dest=/etc/yum.repos.d/pbis.repo
 
-   - name: refresh yum cache
+   - name: Redhat | refresh yum cache
      command: yum --disablerepo=* --enablerepo=pbis clean all
 
-   - name: install pbis
+   - name: Redhat | install pbis
      yum: name=pbis* state=latest

--- a/roles/pbis/tasks/redhat.yml
+++ b/roles/pbis/tasks/redhat.yml
@@ -1,0 +1,11 @@
+---
+# tasks file for pbis on Redhat
+
+   - name: copy pbis.repo file
+     template: src=pbis.repo.j2 dest=/etc/yum.repos.d/pbis.repo
+
+   - name: refresh yum cache
+     command: yum --disablerepo=* --enablerepo=pbis clean all
+
+   - name: install pbis
+     yum: name=pbis* state=latest

--- a/roles/pbis/tasks/ubuntu.yml
+++ b/roles/pbis/tasks/ubuntu.yml
@@ -9,7 +9,7 @@
      apt_repository: repo='deb http://repo.pbis.beyondtrust.com/apt pbiso main' state=present
 
    - name: Ubuntu | apt-get update
-     apt: update_cache=yes
+     apt: update_cache=yes cache_valid_time=3600
 
    - name: Ubuntu | apt-get install pbis-open
      apt: name=pbis-open state=latest

--- a/roles/pbis/tasks/ubuntu.yml
+++ b/roles/pbis/tasks/ubuntu.yml
@@ -1,0 +1,15 @@
+---
+# tasks file for pbis on Ubuntu
+# repo info available: http://repo.pbis.beyondtrust.com/apt.html
+
+   - name: add BeyondTrust PBIS open apt repo key
+     apt_key: url=http://repo.pbis.beyondtrust.com/yum/RPM-GPG-KEY-pbis
+
+   - name: add BeyondTrust PBIS open apt repo
+     apt_repository: repo='deb http://repo.pbis.beyondtrust.com/apt pbiso main' state=present
+
+   - name: apt-get update
+     apt: update_cache=yes
+
+   - name: apt-get install pbis-open
+     apt: name=pbis-open state=latest

--- a/roles/pbis/tasks/ubuntu.yml
+++ b/roles/pbis/tasks/ubuntu.yml
@@ -2,14 +2,14 @@
 # tasks file for pbis on Ubuntu
 # repo info available: http://repo.pbis.beyondtrust.com/apt.html
 
-   - name: add BeyondTrust PBIS open apt repo key
+   - name: Ubuntu | add BeyondTrust PBIS open apt repo key
      apt_key: url=http://repo.pbis.beyondtrust.com/yum/RPM-GPG-KEY-pbis
 
-   - name: add BeyondTrust PBIS open apt repo
+   - name: Ubuntu | add BeyondTrust PBIS open apt repo
      apt_repository: repo='deb http://repo.pbis.beyondtrust.com/apt pbiso main' state=present
 
-   - name: apt-get update
+   - name: Ubuntu | apt-get update
      apt: update_cache=yes
 
-   - name: apt-get install pbis-open
+   - name: Ubuntu | apt-get install pbis-open
      apt: name=pbis-open state=latest

--- a/roles/pbis/templates/pbis.repo.j2
+++ b/roles/pbis/templates/pbis.repo.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 [pbis]
 name=pbis
-baseurl={{ url }}
+baseurl={{ redhat_repo_url }}
 enabled=1
 gpgcheck=0

--- a/roles/pbis/vars/main.yml
+++ b/roles/pbis/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 # vars file for pbis
-username: user_with_ad_rights
-password: a_randon_password
-url: "http://packages.domain.local/pbis/"
-mydomain: MYDOMAIN
+domain_fqdn: office.contoso.com
+domain_netbios: CONTOSO
+domain_user: USERNAME
+domain_pass: PASSWORD
+
+redhat_repo_url: "http://packages.domain.local/pbis/"

--- a/site.yml
+++ b/site.yml
@@ -3,3 +3,6 @@
 # file: site.yml
   - include: redhat.yml
     when: ansible_os_family == "RedHat" and ansible_lsb.major_release|int >= 6
+
+  - include: ubuntu.yml
+    when: ansible_lsb.id == "Ubuntu" and ansible_lsb.major_release|int >= 14

--- a/ubuntu.yml
+++ b/ubuntu.yml
@@ -1,0 +1,6 @@
+---
+
+# file: ubuntu.yml
+ - hosts: all
+   roles:
+       - pbis


### PR DESCRIPTION
Hi Alen,

I've added Ubuntu support (add beyondtrust apt repo, apt key, install apt package)
I also made it a bit more generic for multi OS support.

The Ubuntu part looks to be working in my test environment, I haven't tested the Redhat implementation since making any of these changes.

Cheers,
Rob
