### PR TITLE
Removed URL var reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Ansible playbook for deploying PowerBroker Identity Services (PBIS) Open Edition
 * `domain_user:` and `domain_pass:` of a domain user with granted add/remove computers to the domain
 * `domain_fqdn:` Full qualified domain name of your domain, e.g. office.contoso.com
 * `domain_netbios:` NetBIOS domain name, e.g. CONTOSO
-* `url:` http adress of your yum repo if using Redhat
 
 * `homedir_template:` homedir to be created for logging in users
 * `login_shell_template:` Login shell to be used for remote users


### PR DESCRIPTION
Hi Alen,

Just a cosmetic change. Also I've updated the REPO to be named "Ansible-PBISOpen" on my side.

It's a bit more reflective, Likewise is no more.. It's now BeyondTrust.

Any chance we can get these changes and the latest code sent up to the Ansible Galaxy? If you would like, I'm happy to be the maintainer.

Cheers,
Rob
